### PR TITLE
feat(reset): set preview margins and paddings to 0 by default

### DIFF
--- a/example/.storybook/preview-head.html
+++ b/example/.storybook/preview-head.html
@@ -1,5 +1,0 @@
-<style>
-  body {
-    margin: 0;
-  }
-</style>

--- a/example/package.json
+++ b/example/package.json
@@ -6,16 +6,16 @@
     "storybook": "start-storybook -p 6006"
   },
   "dependencies": {
-    "react": "^16.13.1"
+    "react": "^17.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.11.6",
-    "@storybook/addon-essentials": "6.0.21",
-    "@storybook/addon-links": "6.0.21",
-    "@storybook/addons": "6.0.21",
-    "@storybook/react": "6.0.21",
-    "@storybook/theming": "6.0.21",
-    "babel-loader": "8.1.0",
+    "@babel/core": "^7.0.0",
+    "@storybook/addon-essentials": "^6.0.0",
+    "@storybook/addon-links": "^6.0.0",
+    "@storybook/addons": "^6.0.0",
+    "@storybook/react": "^6.0.0",
+    "@storybook/theming": "^6.0.0",
+    "babel-loader": "^8.0.0",
     "storybook-addon-paddings": "file:../"
   }
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,6 +1,6 @@
 export const ADDON_ID = 'storybook/paddings';
 export const PARAM_KEY = 'paddings';
-export const DEFAULT_PADDING = '';
+export const DEFAULT_PADDING = '0';
 
 export const EVENTS = {
   UPDATE: `${ADDON_ID}/update`,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ const state: {
 };
 
 const setStyle = (padding = DEFAULT_PADDING) => {
+  document.body.style.margin = '0';
   document.body.style.padding = padding;
   document.body.style.transition = 'padding .3s';
 };


### PR DESCRIPTION
Storybook 6.1 introduces the [`layout` parameter](https://storybook.js.org/docs/react/configure/story-layout), set to `padded` by default.

This PR sets the preview margins and paddings to `0` by default, so users are not required to change the `layout` option to `fullscreen` when using the addon. It also ensures that both are reset in older Storybook versions, or when the `none` option is used.