### PR TITLE
feat(mode): support MDX stories in docs view mode

### DIFF
--- a/example/.storybook/main.js
+++ b/example/.storybook/main.js
@@ -4,5 +4,5 @@ module.exports = {
     '@storybook/addon-storysource',
     'storybook-addon-paddings',
   ],
-  stories: ['../src/**/*.stories.js'],
+  stories: ['../src/**/*.stories.@(js|mdx)'],
 };

--- a/example/src/Card.stories.mdx
+++ b/example/src/Card.stories.mdx
@@ -1,0 +1,25 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import Card from './Card';
+
+<Meta title="MDX" component={Card} />
+
+# Inline Story
+
+<Canvas>
+  <Story name="Example">
+    <Card>This story is defined inside a MDX canvas</Card>
+  </Story>
+</Canvas>
+
+# From Single Story ID
+
+<Canvas>
+  <Story name="Preset Options" id="example--preset-options" />
+</Canvas>
+
+# From Multiple Story IDs
+
+<Canvas>
+  <Story name="Custom Options" id="example--custom-options" />
+  <Story name="Default Option" id="example--default-option" />
+</Canvas>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,12 @@ const WithPaddings: StoryWrapper = (getStory, context) => {
   const paddingsConfig = parameters[PARAM_KEY];
   const isInDocs = viewMode === 'docs';
   const selector = isInDocs
-    ? `#anchor--${id} .docs-story > div:first-child`
+    ? [
+        `#anchor--${id} .docs-story > div:first-child`,
+        // Workaround for MDX stories in docs view mode
+        // https://github.com/storybookjs/storybook/issues/14322
+        `#anchor--${id} ~ .sbdocs-preview .docs-story > div:first-child`,
+      ].join()
     : '.sb-show-main';
 
   const selectedPadding = useMemo(
@@ -38,6 +43,8 @@ const WithPaddings: StoryWrapper = (getStory, context) => {
   );
 
   const paddingStyles = useMemo(
+    // Undo default `padded` layout styles
+    // https://github.com/storybookjs/storybook/issues/12135
     () => `
       ${selector} {
         margin: 0;


### PR DESCRIPTION
Support MDX stories in docs view mode by applying CSS styles with specific anchor sibling selectors as a workaround to https://github.com/storybookjs/storybook/issues/14322.

Also add MDX stories to the Storybook example.

Closes #28.